### PR TITLE
Fix double margin and label issue

### DIFF
--- a/module/templates/generic/mod_login_1cl.html5
+++ b/module/templates/generic/mod_login_1cl.html5
@@ -25,8 +25,8 @@ $btnClass = Netzmacht\Bootstrap\Core\Bootstrap::getConfigVar('form.default-submi
       </div>
       <?php if ($this->autologin): ?>
       <div class="checkbox_container checkbox">
-        <label>
-          <input type="checkbox" name="autologin" id="autologin" value="1" class="checkbox"> <label for="autologin"><?php echo $this->autoLabel; ?></label>
+        <label for="autologin">
+          <input type="checkbox" name="autologin" id="autologin" value="1" class="checkbox"> <?php echo $this->autoLabel; ?>
         </label>
       </div>
       <?php endif; ?>


### PR DESCRIPTION
Remove the `label` inside `label` and add `for="autologin"` to the main `label`.